### PR TITLE
Updated basic/Makefile and package/Makefile

### DIFF
--- a/basic/Makefile
+++ b/basic/Makefile
@@ -21,5 +21,7 @@ clean:
 
 
 .bc.klee:
+	opt -mem2reg $< > $*1.bc
+	mv -f $*1.bc $<
 	${KLEE_HOME}/bin/klee -search=dfs -output-dir=$@ ${EXTRA_OPTIONS} $<
 

--- a/package/Makefile
+++ b/package/Makefile
@@ -4,6 +4,8 @@ EXTRA_OPTIONS=-precision -debug-precision
 LLVM_COMPILER=clang
 
 %.klee: build
+	opt -mem2reg adpcm/src/$*.bc > adpcm/src/$*1.bc
+	mv -f adpcm/src/$*1.bc adpcm/src/$*.bc
 	time klee ${EXTRA_OPTIONS} -output-dir=$*.klee adpcm/src/$*.bc
 
 build:


### PR DESCRIPTION
@Himeshi This is to apply LLVM [mem2reg](http://llvm.org/docs/Passes.html#mem2reg-promote-memory-to-register) analysis before inputting the bitcode to KLEE. `mem2reg` is required by the loop analyses (`LoopInfo` and `ScalarEvolution`) to infer loop trip count.