### PR TITLE
Made generation of bitcode and LLVM source go through mem2reg

### DIFF
--- a/basic/Makefile
+++ b/basic/Makefile
@@ -14,14 +14,13 @@ clean:
 .SUFFIXES: .bc .klee .ll
 
 .c.bc:
-	${CC} -c -emit-llvm -g $<
+	${CC} -c -emit-llvm -g -o $*_123.bc $<
+	opt -mem2reg < $*_123.bc > $@
+	rm -f $*_123.bc
 
-.c.ll:
-	${CC} -c -emit-llvm -g -S $<
-
+.bc.ll:
+	llvm-dis $<
 
 .bc.klee:
-	opt -mem2reg $< > $*1.bc
-	mv -f $*1.bc $<
 	${KLEE_HOME}/bin/klee -search=dfs -output-dir=$@ ${EXTRA_OPTIONS} $<
 

--- a/package/Makefile
+++ b/package/Makefile
@@ -6,8 +6,8 @@ SYM_OPTIONS=-sym-stdin 60000
 LLVM_COMPILER=clang
 
 %.klee: build
-	opt -mem2reg adpcm/src/$*.bc > adpcm/src/$*1.bc
-	mv -f adpcm/src/$*1.bc adpcm/src/$*.bc
+	opt -mem2reg adpcm/src/$*.bc > adpcm/src/$*_123.bc
+	mv -f adpcm/src/$*_123.bc adpcm/src/$*.bc
 	time klee ${EXTRA_OPTIONS} -output-dir=$*.klee adpcm/src/$*.bc ${SYM_OPTIONS}
 
 build:


### PR DESCRIPTION
@Himeshi Now in `basic` folder one can do `make <program_name>.ll` or `make <program_name>.bc` and the LLVM code generated will have been processed through `mem2reg`.