### PR TITLE
Updated calls to klee_bound_error() to take name string

### DIFF
--- a/basic/add_test.c
+++ b/basic/add_test.c
@@ -17,7 +17,7 @@ int main() {
 
   answer = add(a, b);
 
-  klee_bound_error(answer, 1.3);
+  klee_bound_error(answer, "answer", 1.3);
   return 0;
 }
 

--- a/basic/add_test2.c
+++ b/basic/add_test2.c
@@ -13,7 +13,7 @@ int main() {
   klee_track_error(&a, "error_a");
   klee_track_error(&b, "error_b");
   answer = add(a, b);
-  klee_bound_error(answer, 1.3);
+  klee_bound_error(answer, "answer", 1.3);
   return 0;
 }
 int add(int x, int y) { return (x + y) * (x - y); }

--- a/basic/adpcm_encoder_constant_iter.c
+++ b/basic/adpcm_encoder_constant_iter.c
@@ -200,7 +200,7 @@ int main(int argc, char *argv[]) {
     
   adpcm_coder(sbuf, abuf, n/2, &state);
 
-  klee_bound_error(abuf[0], 1.3);
+  klee_bound_error(abuf[0], "abuf[0]", 1.3);
 
   return 0;
 }

--- a/basic/array_test1.c
+++ b/basic/array_test1.c
@@ -25,7 +25,7 @@ int main() {
 
   test_array(arr);
 
-  klee_bound_error(arr[0], 1.3);
+  klee_bound_error(arr[0], "arr[0]", 1.3);
   return 0;
 }
 

--- a/basic/array_test2.c
+++ b/basic/array_test2.c
@@ -27,7 +27,7 @@ int main() {
 
   test_array(arr);
 
-  klee_bound_error(arr[0], 1.3);
+  klee_bound_error(arr[0], "arr[0]", 1.3);
   return 0;
 }
 

--- a/basic/array_test3.c
+++ b/basic/array_test3.c
@@ -25,7 +25,7 @@ int main() {
 
   test_array(arr);
 
-  klee_bound_error(arr[0], 1.3);
+  klee_bound_error(arr[0], "arr[0]", 1.3);
   return 0;
 }
 

--- a/basic/array_test4.c
+++ b/basic/array_test4.c
@@ -25,7 +25,7 @@ int main() {
 
   test_array(arr);
 
-  klee_bound_error(arr[0], 1.3);
+  klee_bound_error(arr[0], "arr[0]", 1.3);
   return 0;
 }
 

--- a/basic/branch.c
+++ b/basic/branch.c
@@ -22,7 +22,7 @@ int main()
         output = input_x * input_y;
     }
 
-    klee_bound_error(output, 1.3);
+    klee_bound_error(output, "output", 1.3);
 
     return 0;
 }

--- a/basic/cascading.c
+++ b/basic/cascading.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  klee_bound_error(c, 1.3);
+  klee_bound_error(c, "c", 1.3);
 
   return 0;
 }

--- a/basic/foo1.c
+++ b/basic/foo1.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
 
   klee_make_symbolic(&input, sizeof(input), "input");
 
-  klee_bound_error(foo1(input), 0.0);
+  klee_bound_error(foo1(input), "foo1(input)", 0.0);
 
   return 0;
 }

--- a/basic/foo2.c
+++ b/basic/foo2.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
 
   klee_make_symbolic(&input, sizeof(input), "input");
 
-  klee_bound_error(foo2(input), 0.01);
+  klee_bound_error(foo2(input), "foo2(input)", 0.01);
 
   return 0;
 }

--- a/basic/get_sign.c
+++ b/basic/get_sign.c
@@ -26,7 +26,7 @@ int main()
  
     output = calculate_output(input_x, input_y);
 
-    klee_bound_error(output, 1.3);
-    
+    klee_bound_error(output, "output", 1.3);
+
     return 0;
 }

--- a/basic/gsl.c
+++ b/basic/gsl.c
@@ -38,8 +38,8 @@ int main(int argc, char **argv) {
 
   gsl_sf_bessel_Knu_scaled_asympx_e(nu, x, r);
 
-  klee_bound_error(r->val, 0.1);
-  klee_bound_error(r->err, 0.1);
-  
+  klee_bound_error(r->val, "r->val", 0.1);
+  klee_bound_error(r->err, "r->err", 0.1);
+
   return 0;
 }

--- a/basic/kahan.c
+++ b/basic/kahan.c
@@ -14,7 +14,7 @@ void test(int N,float* x) {
 
     // The klee_bound_error below is a replacement of:
     // assert(Debug.checkAccuracy(sum,0.01f,"a"));
-    klee_bound_error(sum, 0.0);
+    klee_bound_error(sum, "sum", 0.0);
   }
 }
 

--- a/basic/linear.c
+++ b/basic/linear.c
@@ -15,31 +15,31 @@ void test(int r, float in0) {
 
       // The following replaces
       // assert(Debug.checkAccuracy(x0,0.01f,"a"));
-      klee_bound_error(x0, 0.01);
-      
+      klee_bound_error(x0, "x0", 0.01);
+
       x1=0.3167f * x0 + 0.1016f * x1 - 0.4444f *x2 + 0.1807f * in0;
 
       // The following replaces
       // assert(Debug.checkAccuracy(x1,0.01f,"a"));
-      klee_bound_error(x1, 0.01);
-      
+      klee_bound_error(x1, "x1", 0.01);
+
       x2=0.1278f * x0 + 0.4444f * x1 + 0.8207f * x2 + 0.0729f * in0;
 
       // The following replaces
       // assert(Debug.checkAccuracy(x2,0.01f,"a"));
-      klee_bound_error(x2, 0.01);
-      
+      klee_bound_error(x2, "x2", 0.01);
+
       x3 = 0.0365f * x0 + 0.1270f * x1 + 0.5202f * x2 + 0.4163f * x3 - 0.5714f * x4 + 0.0208f * in0;
       
       // The following replaces
       // assert(Debug.checkAccuracy(x3,0.01f,"a"));
-      klee_bound_error(x3, 0.01);
-      
+      klee_bound_error(x3, "x3", 0.01);
+
       x4 = 0.0147f * x0 + 0.0512f * x1 + 0.2099f * x2 + 0.57104f * x3 + 0.7694f * x4 + 0.0084f * in0;
 
       // The following replaces
       // assert(Debug.checkAccuracy(x4,0.01f,"a"));
-      klee_bound_error(x4, 0.01);
+      klee_bound_error(x4, "x4", 0.01);
     }
   }
 }

--- a/basic/loop.c
+++ b/basic/loop.c
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
   klee_assert(klee_is_symbolic(d));
 
   // Bound the error
-  klee_bound_error(c, 1.3);
+  klee_bound_error(c, "c", 1.3);
 
   return 0;
 }

--- a/basic/loop_branching1.c
+++ b/basic/loop_branching1.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
   }
 
   // Bound the error
-  klee_bound_error(c, 1.3);
+  klee_bound_error(c, "c", 1.3);
 
   return 0;
 }

--- a/basic/loop_branching2.c
+++ b/basic/loop_branching2.c
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
   }
 
   // Bound the error
-  klee_bound_error(c, 1.3);
+  klee_bound_error(c, "c", 1.3);
 
   return 0;
 }

--- a/basic/loop_branching3.c
+++ b/basic/loop_branching3.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
   }
 
   // Bound the error
-  klee_bound_error(c, 1.3);
+  klee_bound_error(c, "c", 1.3);
 
   return 0;
 }

--- a/basic/loop_single_iter.c
+++ b/basic/loop_single_iter.c
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
     c++;
   }
 
-  klee_bound_error(c, 1.3);
+  klee_bound_error(c, "c", 1.3);
 
   return 0;
 }

--- a/basic/loop_unknown_iter.c
+++ b/basic/loop_unknown_iter.c
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
 
   c = loop(c, bound);
 
-  klee_bound_error(c, 1.3);
+  klee_bound_error(c, "c", 1.3);
 
   return 0;
 }

--- a/basic/mat_mul.c
+++ b/basic/mat_mul.c
@@ -22,7 +22,7 @@ int main() {
 	for (inner = 0; inner < 2; inner++) {
 	  product[row][col] += aMatrix[row][inner] * bMatrix[inner][col];
 	}
-	klee_bound_error(product[row][col], 0.01); 
+        klee_bound_error(product[row][col], "product[row][col]", 0.01);
       }
     }
     

--- a/basic/sterbenz.c
+++ b/basic/sterbenz.c
@@ -50,8 +50,8 @@ int main(int argc, char **argv) {
   klee_make_symbolic(&in1, sizeof(in1), "in1");
   klee_make_symbolic(&in2, sizeof(in2), "in2");
 
-  klee_bound_error(average(in1, in2), 0.01);
-  
+  klee_bound_error(average(in1, in2), "average(in1, in2)", 0.01);
+
   return 0;
 }
 

--- a/basic/summation.c
+++ b/basic/summation.c
@@ -12,7 +12,7 @@ void test(int N, float* x) {
     
     // The following replaces
     // assert(Debug.checkAccuracy(sum,0.01f,"a"));
-    klee_bound_error(sum, 0.01);
+    klee_bound_error(sum, "sum", 0.01);
   }
 }
 


### PR DESCRIPTION
To adapt to the new API introduced by fp-analysis/klee#42.