### PR TITLE
Simple example of symbolic index

### DIFF
--- a/basic/symbolic_index.c
+++ b/basic/symbolic_index.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 National University of Singapore
+ */
+#include <klee/klee.h>
+#include <stdio.h>
+
+#define SIZE 5
+
+int main() {
+  char arr[SIZE];
+  int i;
+
+  klee_make_symbolic(&i, sizeof(i), "i");
+  klee_track_error(&i, "error_i");
+  
+  klee_assume(0 <= i);
+  klee_assume(i < 5);
+  
+  char n = arr[i];
+  
+  return n;
+}
+


### PR DESCRIPTION
Added first version of `basic/symbolic_index.c`. This simple example triggered the bug fixed by fp-analysis/klee#58. It may be good to keep it for regression testing.
